### PR TITLE
Remove polygonOffset from grate textures

### DIFF
--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -1112,8 +1112,6 @@ textures/shared_vega/grate01
 	surfaceparm nomarks
 	surfaceparm metalsteps
 
-	// polygonOffset fixes Z-fighting with objects on top of the grate
-	polygonOffset
 	cull none
 
 	imageMinDimension 256
@@ -1157,8 +1155,6 @@ textures/shared_vega/grate02
 	surfaceparm nomarks
 	surfaceparm metalsteps
 
-	// polygonOffset fixes Z-fighting with objects on top of the grate
-	polygonOffset
 	cull none
 
 	imageMinDimension 128


### PR DESCRIPTION
This is not a good use of polygonOffset. It is meant for a surface that overlaps another surface but needs to be drawn above it.

The use of polygonOffset here seems to be a trigger for https://github.com/DaemonEngine/Daemon/issues/1676. It may be related to the fact that polygonOffset disables the depth shader from being generated. No depth shader also has the deleterious effect of making realtime lights unable to affect the surface.