### PR TITLE
Various materials tweaks related to light and shadows

### DIFF
--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -1009,6 +1009,7 @@ textures/shared_vega/trim03b_white_1000
 	}
 
 	q3map_surfacelight 1000
+	q3map_lightSubdivide 16
 }
 
 textures/shared_vega/trim03b_green_1000
@@ -1025,6 +1026,7 @@ textures/shared_vega/trim03b_green_1000
 	q3map_lightRGB .702 1 .702
 
 	q3map_surfacelight 1000
+	q3map_lightSubdivide 16
 }
 
 textures/shared_vega/trim04

--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -1018,6 +1018,8 @@ textures/shared_vega/trim03b_green_1000
 
 	{
 		diffuseMap textures/shared_vega_src/trim03b_light_d
+		normalMap textures/shared_vega_src/trim03_n
+		normalFormat -X -Y Z
 		specularMap textures/shared_vega_src/trim03b_light_s
 		glowMap textures/shared_vega_src/trim03b_green_a
 	}

--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -479,6 +479,7 @@ textures/shared_vega/panel08a_300
 
 	q3map_surfacelight 300
 	q3map_lightRGB 1 1 .93
+	q3map_lightSubdivide 16
 }
 
 // metal panel with round blue lights

--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -1112,6 +1112,7 @@ textures/shared_vega/grate01
 
 	surfaceparm nomarks
 	surfaceparm metalsteps
+	surfaceparm alphashadow
 
 	cull none
 
@@ -1134,6 +1135,7 @@ textures/shared_vega/grate01_nonsolid
 	surfaceparm nomarks
 	surfaceparm nonsolid
 	surfaceparm metalsteps
+	surfaceparm alphashadow
 
 	cull none
 
@@ -1155,6 +1157,7 @@ textures/shared_vega/grate02
 
 	surfaceparm nomarks
 	surfaceparm metalsteps
+	surfaceparm alphashadow
 
 	cull none
 
@@ -1177,6 +1180,7 @@ textures/shared_vega/grate02_nonsolid
 	surfaceparm nomarks
 	surfaceparm nonsolid
 	surfaceparm metalsteps
+	surfaceparm alphashadow
 
 	cull none
 

--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -804,6 +804,8 @@ textures/shared_vega/glass01
 	qer_editorImage textures/shared_vega_src/glass01_b
 	qer_trans .7
 
+	surfaceparm alphashadow
+
 	cull none
 
 	{

--- a/scripts/shared_vega.shader
+++ b/scripts/shared_vega.shader
@@ -330,6 +330,7 @@ textures/shared_vega/panel05_300
 	}
 
 	q3map_surfacelight 300
+	q3map_lightSubdivide 16
 }
 
 textures/shared_vega/panel05_500
@@ -345,6 +346,7 @@ textures/shared_vega/panel05_500
 	}
 
 	q3map_surfacelight 500
+	q3map_lightSubdivide 16
 }
 
 // panel with lights (centered)
@@ -361,6 +363,7 @@ textures/shared_vega/panel06_300
 	}
 
 	q3map_surfacelight 300
+	q3map_lightSubdivide 16
 }
 
 textures/shared_vega/panel06_500
@@ -376,6 +379,7 @@ textures/shared_vega/panel06_500
 	}
 
 	q3map_surfacelight 500
+	q3map_lightSubdivide 16
 }
 
 textures/shared_vega/panel06broken


### PR DESCRIPTION
- Subdivide some lights, avoid light blotches that made neon lights looking like point lights.

Before:

![unvanquished_2026-02-25_185324_000](https://github.com/user-attachments/assets/455dc326-dce3-4e58-b512-c02ebcedc7be)

After:

![unvanquished_2026-02-25_192434_000](https://github.com/user-attachments/assets/f04e5430-5bd2-440b-b154-030449c0929a)

- Make glass pass light properly.

Before:

![unvanquished_2026-03-03_114205_000](https://github.com/user-attachments/assets/67cf39c3-b75f-4a35-bf53-d6cbc0892d17)

After:

![unvanquished_2026-03-03_114233_000](https://github.com/user-attachments/assets/4a4f5997-5d30-4d1d-9852-ed25c7aef11a)

Also make some grates project shadow.

Before:

![unvanquished_2026-02-25_114551_000](https://github.com/user-attachments/assets/9c5f14a4-e425-4fb6-8cea-349a61090cf9)

After:

![unvanquished_2026-02-25_144345_000](https://github.com/user-attachments/assets/f725a43c-fd2a-4213-b4ba-ad55a4bb0534)

The shadows being a bit different on the wall on the right it's unrelated, it was me also testing something else at the same time.

Now with both glass letting light pass through, and grates projecting shadows:

![unvanquished_2026-02-25_165151_000](https://github.com/user-attachments/assets/73fc6efe-93be-48c1-a2bc-2facb456d3ab)

